### PR TITLE
[admin] Fix preview security

### DIFF
--- a/admin/apercu.php
+++ b/admin/apercu.php
@@ -1,0 +1,29 @@
+<?php
+# *** LICENSE ***
+# This file is part of BlogoText.
+# http://lehollandaisvolant.net/blogotext/
+#
+# 2006      Frederic Nassar.
+# 2010-2015 Timo Van Neerden <timo@neerden.eu>
+#
+# BlogoText is free software.
+# You can redistribute it under the terms of the MIT / X11 Licence.
+#
+# *** LICENSE ***
+
+$GLOBALS['BT_ROOT_PATH'] = '../';
+require_once '../inc/inc.php';
+error_reporting($GLOBALS['show_errors']);
+
+operate_session();
+
+// OPEN BASE
+$GLOBALS['db_handle'] = open_base($GLOBALS['db_location']);
+
+// RECUP INFOS ARTICLE
+if (isset($_GET['post_id'])) {
+	$article_id = htmlspecialchars($_GET['post_id']);
+	$query = "SELECT * FROM articles WHERE bt_id LIKE ?";
+	$posts = liste_elements($query, array($article_id), 'articles');
+	if (isset($posts[0])) apercu($posts[0]);
+}

--- a/admin/ecrire.php
+++ b/admin/ecrire.php
@@ -77,7 +77,7 @@ echo '<div id="page">'."\n";
 
 // EDIT
 if ($post != '') {
-	apercu($post);
+	echo '<iframe id="apercu" src="apercu.php?post_id='.$_GET['post_id'].'" sandbox="allow-same-origin" seamless="" scrolling="no" onload="resizeIframe(this);"></iframe>';
 }
 afficher_form_billet($post, $erreurs_form);
 

--- a/admin/style/javascript.js
+++ b/admin/style/javascript.js
@@ -78,7 +78,7 @@ function unfold(button) {
 }
 
 
-/* 
+/*
 	When a file is uploaded, the input containing the html/bbcode code is clicable.
 	On clic, all text is selected.
 */
@@ -244,7 +244,7 @@ function request_delete_form(id) {
 	};
 
 	// prepare and send FormData
-	var formData = new FormData();  
+	var formData = new FormData();
 	formData.append('supprimer', '1');
 	formData.append('file_id', id);
 	xhr.send(formData);
@@ -334,3 +334,14 @@ function hide_forms(blocs) {
 	}
 }
 
+
+
+
+
+
+/*
+	in page ecrire : adjust preview iFrame height.
+*/
+function resizeIframe(obj) {
+	obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+}

--- a/admin/style/style-ecrire.css
+++ b/admin/style/style-ecrire.css
@@ -1,23 +1,27 @@
-/* ECRIRE 
+/* ECRIRE
 ---------------------------------------------------------------------------------- */
 
 /* apercu */
 #apercu {
-	padding: 5px;
-	box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	margin: 0 0 20px 0;
+	width: 100%;
 	border: 1px dashed #ccc;
+	margin: 0 0 20px 0;
+	font-size: 12px;
 }
 
-#apercu p {
+.apercu pre, .apercu code {
+	white-space: pre-wrap;
+}
+
+.apercu p {
 	margin-top: 5px;
 	margin-bottom: 5px;
 }
 
-#apercu img {
+.apercu img {
 	padding: 2px;
 	border: 1px solid #ddd;
+	max-width: 100%;
 }
 
 /* formulaire à remplir */

--- a/inc/html.php
+++ b/inc/html.php
@@ -90,12 +90,10 @@ function afficher_msg($titre) {
 }
 
 function apercu($article) {
-	if (isset($article)) {
-		$apercu = '<h2>'.$article['bt_title'].'</h2>'."\n";
-		$apercu .= '<div><strong>'.$article['bt_abstract'].'</strong></div>'."\n";
-		$apercu .= '<div>'.rel2abs_admin($article['bt_content']).'</div>'."\n";
-		echo '<div id="apercu">'."\n".$apercu.'</div>'."\n\n";
-	}
+	$apercu = '<h2>'.$article['bt_title'].'</h2>'."\n";
+	$apercu .= '<div><strong>'.$article['bt_abstract'].'</strong></div>'."\n";
+	$apercu .= '<div>'.rel2abs_admin($article['bt_content']).'</div>'."\n";
+	echo '<div class="apercu">'."\n".$apercu.'</div>';
 }
 
 function moteur_recherche($placeholder) {
@@ -282,7 +280,7 @@ function encart_commentaires() {
 		$listeLastComments = '<ul class="encart_lastcom">'."\n";
 		foreach ($tableau as $i => $comment) {
 			$comment['contenu_abbr'] = strip_tags($comment['bt_content']);
-			// limits length of comment abbreviation and name 
+			// limits length of comment abbreviation and name
 			if (strlen($comment['contenu_abbr']) >= 60) {
 				$comment['contenu_abbr'] = mb_substr($comment['contenu_abbr'], 0, 59).'…';
 			}


### PR DESCRIPTION
__Scénario__
J'oublie de fermer une double quote dans le corps de l'article. J'enregistre le brouillon.
L'aperçu est complètement éclaté, les formulaires ne s'y retrouvent plus et du coup pas moyen d'apporter de modifications, ne serait-ce que pour corriger l'oubli. Il faudrait se connecter manuellement à la BDD pour corriger le texte.

__Solution__
Afficher l'aperçu dans une iFrame.
La hauteur s'adaptera automatiquement au contenu.

Dans `apercu()`, j'ai supprimé la vérification de `$post` puisque tu le fais déjà dans le fichier ecrire.php.