### PR TITLE
[PHP] Fix articles list

### DIFF
--- a/inc/html.php
+++ b/inc/html.php
@@ -404,11 +404,8 @@ function afficher_liste_articles($tableau) {
 			// ICONE SELON STATUT
 			$out .= "\t".'<li>'."\n";
 			// TITRE
-			$out .= "\t\t".'<span><span class="'.( ($article['bt_statut'] == '1') ? 'on' : 'off').'"></span>'.'<a href="ecrire.php?post_id='.$article['bt_id'].'" title="'.trim(mb_substr(strip_tags($article['bt_abstract']), 0, 249)).'">'.$article['bt_title'].'</a>'.'</span>'."\n";
+			$out .= "\t\t".'<span><span class="'.( ($article['bt_statut'] == '1') ? 'on' : 'off').'"></span>'.'<a href="ecrire.php?post_id='.$article['bt_id'].'" title="'.htmlspecialchars(trim(mb_substr(strip_tags($article['bt_abstract']), 0, 249)), ENT_QUOTES).'">'.$article['bt_title'].'</a>'.'</span>'."\n";
 			// DATE
-
-
-
 			$out .= "\t\t".'<span><a href="'.basename($_SERVER['PHP_SELF']).'?filtre='.substr($article['bt_date'],0,8).'">'.date_formate($article['bt_date']).'</a> @ '.heure_formate($article['bt_date']).'</span>'."\n";
 			// NOMBRE COMMENTS
 			$texte = $article['bt_nb_comments'];


### PR DESCRIPTION
Dans le panneau admin , si dans le châpo il y a des doubles quotes, le code HTML généré est erroné. L'attribut `title` des articles est cassé.