### PR TITLE
avoid big images to overlap

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -121,6 +121,8 @@ main {
 	margin-right: 280px;
 }
 
+#contenu img { max-width:100%; }
+
 #sidebar {
 	float: right;
 	padding: 10px;


### PR DESCRIPTION
Les images trop grandes sortent du cadre de l'article, rendant un ensemble très moche.
Avec juste ce petit bout de css, ça semble réglé.