### PR TITLE
Use posts dates to guess previous/next months to show on the calendar

### DIFF
--- a/addons/calendrier.php
+++ b/addons/calendrier.php
@@ -15,7 +15,49 @@
 // include this addon
 $GLOBALS['addons'][] = array('tag' => '{calendrier}', 'callback_function' => 'addon_calendrier');
 
-// returns HTML <table> calender
+// returns a list of days containing at least one post for a given month
+function table_list_date($date, $table) {
+	$return = array();
+	$column = ($table == 'articles') ? 'bt_date' : 'bt_id';
+	$and_date = 'AND '.$column.' <= '.date('YmdHis');
+
+	$query = "SELECT DISTINCT SUBSTR($column, 7, 2) AS date FROM $table WHERE bt_statut = 1 AND $column LIKE '$date%' $and_date";
+
+	try {
+		$req = $GLOBALS['db_handle']->query($query);
+		while ($row = $req->fetch(PDO::FETCH_ASSOC)) {
+			$return[] = $row['date'];
+		}
+		return $return;
+	} catch (Exception $e) {
+		die('Erreur 21436 : '.$e->getMessage());
+	}
+}
+
+// returns dates of the previous and next visible posts
+function prev_next_posts($year, $month, $table) {
+	$column = ($table == 'articles') ? 'bt_date' : 'bt_id';
+	$and_date = 'AND '.$column.' <= '.date('YmdHis');
+
+	$date = new DateTime();
+	$date->setDate($year, $month, 1)->setTime(0, 0, 0);
+	$date_min = $date->format('YmdHis');
+	$date->modify('+1 month');
+	$date_max = $date->format('YmdHis');
+
+	$query = "SELECT
+		(SELECT SUBSTR($column, 0, 7) FROM $table WHERE bt_statut = 1 AND $column < $date_min ORDER BY $column DESC LIMIT 1),
+		(SELECT SUBSTR($column, 0, 7) FROM $table WHERE bt_statut = 1 AND $column > $date_max $and_date ORDER BY $column ASC LIMIT 1)";
+
+	try {
+		$req = $GLOBALS['db_handle']->query($query);
+		return array_values($req->fetch(PDO::FETCH_ASSOC));
+	} catch (Exception $e) {
+		die('Erreur 21436 : '.$e->getMessage());
+	}
+}
+
+// returns HTML <table> calendar
 function addon_calendrier() {
 	// article
 	if ( isset($_GET['d']) and preg_match('#^\d{4}(/\d{2}){5}#', $_GET['d'])) {
@@ -46,17 +88,9 @@ function addon_calendrier() {
 		$GLOBALS['lang']['sa'],
 		$GLOBALS['lang']['di']
 	);
-	$premier_jour = mktime('0', '0', '0', $ce_mois, '1', $annee);
+	$premier_jour = mktime(0, 0, 0, $ce_mois, 1, $annee);
 	$jours_dans_mois = date('t', $premier_jour);
-	$decalage_jour = date('w', $premier_jour-'1');
-	$prev_mois =      '?'.$qstring.'d='.$annee.'/'.str2($ce_mois-1);
-	if ($prev_mois == '?'.$qstring.'d='.$annee.'/'.'00') {
-		$prev_mois =   '?'.$qstring.'d='.($annee-'1').'/'.'12';
-	}
-	$next_mois =      '?'.$qstring.'d='.$annee.'/'.str2($ce_mois+1);
-	if ($next_mois == '?'.$qstring.'d='.$annee.'/'.'13') {
-		$next_mois =   '?'.$qstring.'d='.($annee+'1').'/'.'01';
-	}
+	$decalage_jour = date('w', $premier_jour-1);
 
 	// On verifie si il y a un ou des articles/liens/commentaire du jour dans le mois courant
 	$tableau = array();
@@ -71,16 +105,23 @@ function addon_calendrier() {
 			$where = 'articles'; break;
 	}
 
-	$tableau = table_list_date($annee.$ce_mois, 1, $where);
+	// On cherche les dates des articles précédent et suivant
+	list($previous_post, $next_post) = prev_next_posts($annee, $ce_mois, $where);
+	$prev_mois = '?'.$qstring.'d='.substr($previous_post, 0, 4).'/'.substr($previous_post, 4, 2);
+	$next_mois = '?'.$qstring.'d='.substr($next_post, 0, 4).'/'.substr($next_post, 4, 2);
+
+	$tableau = table_list_date($annee.$ce_mois, $where);
 
 	$html = '<table id="calendrier">'."\n";
 	$html .= '<caption>';
-	$html .= '<a href="'.$prev_mois.'">&#171;</a>&nbsp;';
+	if ($previous_post !== null) {
+		$html .= '<a href="'.$prev_mois.'">&#171;</a>&nbsp;';
+	}
 
 	// Si on affiche un jour on ajoute le lien sur le mois
 	$html .= '<a href="?'.$qstring.'d='.$annee.'/'.$ce_mois.'">'.mois_en_lettres($ce_mois).' '.$annee.'</a>';
 	// On ne peut pas aller dans le futur
-	if ( ($ce_mois != date('m')) || ($annee != date('Y')) ) {
+	if ($next_post !== null) {
 		$html .= '&nbsp;<a href="'.$next_mois.'">&#187;</a>';
 	}
 	$html .= '</caption>'."\n".'<tr>'."\n";

--- a/addons/calendrier.php
+++ b/addons/calendrier.php
@@ -75,9 +75,7 @@ function addon_calendrier() {
 
 	$html = '<table id="calendrier">'."\n";
 	$html .= '<caption>';
-	if ( $annee.$ce_mois > DATE_PREMIER_MESSAGE_BLOG) {
-		$html .= '<a href="'.$prev_mois.'">&#171;</a>&nbsp;';
-	}
+	$html .= '<a href="'.$prev_mois.'">&#171;</a>&nbsp;';
 
 	// Si on affiche un jour on ajoute le lien sur le mois
 	$html .= '<a href="?'.$qstring.'d='.$annee.'/'.$ce_mois.'">'.mois_en_lettres($ce_mois).' '.$annee.'</a>';

--- a/admin/ecrire.php
+++ b/admin/ecrire.php
@@ -34,7 +34,7 @@ if (isset($_POST['_verif_envoi'])) {
 	}
 }
 
-// RECUP INFOS ARTICLE SI DONNÉE
+// RECUP INFOS ARTICLE SI DONNÉ
 $post = '';
 $article_id = '';
 if (isset($_GET['post_id'])) {
@@ -99,4 +99,3 @@ echo '</script>';
 
 
 footer($begin);
-

--- a/admin/style/style-ecrire.css
+++ b/admin/style/style-ecrire.css
@@ -305,7 +305,7 @@ p.formatbut {
 	height: 36px;
 	line-height: 36px;
 	box-sizing: border-box;
-	
+
 }
 
 #selected > li > a {
@@ -334,6 +334,7 @@ p.formatbut {
 	flex: 1 1 auto;
 }
 
+#formdate input,
 #formheure input {
 	background: #FAFAFA;
 	padding: 11px 5px;
@@ -341,6 +342,10 @@ p.formatbut {
 	border: 0;
 	text-align: center;
 	margin-left: 3px;
+}
+
+#formdate input {
+	width: 8ch;
 }
 
 #opts {
@@ -392,5 +397,3 @@ p.formatbut {
 	content: "\e91b";
 	color: rgba(101, 234, 143, 1);
 }
-
-

--- a/inc/fich.php
+++ b/inc/fich.php
@@ -56,15 +56,6 @@ function fichier_adv_conf() {
 	$conf='';
 	$conf .= '; <?php die(); /*'."\n\n";
 	$conf .= '; This file contains some more advanced configuration features.'."\n\n";
-	// get first article date
-	try {
-		$result = $GLOBALS['db_handle']->query("SELECT MIN(bt_date) FROM articles")->fetch();
-		$date = decode_id($result[0]);
-		$conf .= 'DATE_PREMIER_MESSAGE_BLOG = \''.$date['annee'].$date['mois'].'\''."\n";
-	} catch (Exception $e) {
-		die('Erreur MIN in Fichier_adv_conf() gen.: '.$e->getMessage());
-	}
-
 	$conf .= 'BLOG_UID = \''.sha1(uniqid(mt_rand(), true)).'\''."\n";
 	$conf .= 'DISPLAY_PHP_ERRORS = -1;'."\n";
 	$conf .= 'USE_IP_IN_SESSION = 0;'."\n\n\n";
@@ -132,8 +123,8 @@ function fichier_prefs() {
 		$nombre_liens_admin = '50';
 	}
 	$prefs = "<?php\n";
-	$prefs .= "\$GLOBALS['lang'] = '".$lang."';\n";	
-	$prefs .= "\$GLOBALS['auteur'] = '".$auteur."';\n";	
+	$prefs .= "\$GLOBALS['lang'] = '".$lang."';\n";
+	$prefs .= "\$GLOBALS['auteur'] = '".$auteur."';\n";
 	$prefs .= "\$GLOBALS['email'] = '".$email."';\n";
 	$prefs .= "\$GLOBALS['nom_du_site'] = '".$nomsite."';\n";
 	$prefs .= "\$GLOBALS['description'] = '".$description."';\n";
@@ -525,4 +516,3 @@ if (!function_exists('http_parse_headers')) {
 		return $headers;
 	}
 }
-

--- a/inc/form.php
+++ b/inc/form.php
@@ -443,14 +443,7 @@ function afficher_form_billet($article, $erreurs) {
 	$html = '';
 
 	function form_annee($year_shown) {
-		$yearBegin = min (substr(DATE_PREMIER_MESSAGE_BLOG, 0, 4), date('Y') -3);
-		for ($year = $yearBegin, $year_max = date('Y') +3; $year <= $year_max; $year++) $years[$year] = $year;
-		$ret = '<select name="annee">'."\n" ;
-			foreach ($years as $option => $label) {
-				$ret .= "\t".'<option value="'.htmlentities($option).'"'.(($year_shown == $option) ? ' selected="selected"' : '').'>'.htmlentities($label).'</option>'."\n";
-			}
-		$ret .= '</select>'."\n";
-		return $ret;
+		return '<input type="number" name="annee" max="'.(date('Y') + 3).'" value="'.$year_shown.'">'."\n";
 	}
 
 	function form_mois($mois_affiche) {
@@ -1029,4 +1022,3 @@ function afficher_form_prefs($erreurs = '') {
 
 	echo '</form>'."\n";
 }
-

--- a/inc/sqli.php
+++ b/inc/sqli.php
@@ -738,26 +738,6 @@ function nb_entries_as($table, $what) {
 }
 
 
-// retourne la liste les jours d’un mois que le calendrier doit afficher.
-function table_list_date($date, $statut, $table) {
-	$return = array();
-	$and_statut = (!empty($statut)) ? 'AND bt_statut=\''.$statut.'\'' : '';
-	$bt_ = ($table == 'articles') ? 'bt_date' : 'bt_id';
-	$and_date = 'AND '.$bt_.' <= '.date('YmdHis');
-
-	$query = "SELECT DISTINCT substr($bt_, 7, 2) AS date FROM $table WHERE $bt_ LIKE '$date%' $and_statut $and_date";
-
-	try {
-		$req = $GLOBALS['db_handle']->query($query);
-		while ($row = $req->fetch(PDO::FETCH_ASSOC)) {
-			$return[] = $row['date'];
-		}
-		return $return;
-	} catch (Exception $e) {
-		die('Erreur 21436 : '.$e->getMessage());
-	}
-}
-
 function list_all_tags($table, $statut) {
 	try {
 		if ($statut !== FALSE) {
@@ -911,4 +891,3 @@ function traiter_form_rssconf() {
 	redirection($redir);
 
 }
-


### PR DESCRIPTION
This is a patch for the dates. It will use previous/next post date into the calendar, get rid if `DATE_PREMIER_MESSAGE_BLOG` and use a number field on post creation/edition. It will prevent scraping by robots on months with no posts.

On post creation/edition, I set the max year to current year + 3, as it was before.