### PR TITLE
[Addons] Can specifiy CSS/JS files to include and rethink addons tree

### DIFF
--- a/addons/.gitignore
+++ b/addons/.gitignore
@@ -1,3 +1,8 @@
-!calendrier.php
-!readmore.php
+# Ignore everything:
 *
+
+# Except for those addons directories:
+!calendar/
+!calendar/*
+!readmore/
+!readmore/*

--- a/addons/calendar/calendar.php
+++ b/addons/calendar/calendar.php
@@ -9,11 +9,14 @@
 #
 # *** LICENSE ***
 
-# This plugin replaces the {calendrier} tag in the public template with
+# This plugin replaces the {addon_calendar} tag in the public template with
 # a navigable HTML calendar.
 
 // include this addon
-$GLOBALS['addons'][] = array('tag' => '{calendrier}', 'callback_function' => 'addon_calendrier');
+$GLOBALS['addons'][] = array(
+	'name' => 'calendar',  // the same name of this file without ".php"
+	'css' => 'style.css',
+);
 
 // returns a list of days containing at least one post for a given month
 function table_list_date($date, $table) {
@@ -58,7 +61,7 @@ function prev_next_posts($year, $month, $table) {
 }
 
 // returns HTML <table> calendar
-function addon_calendrier() {
+function addon_calendar() {
 	// article
 	if ( isset($_GET['d']) and preg_match('#^\d{4}(/\d{2}){5}#', $_GET['d'])) {
 		$id = substr(str_replace('/', '', $_GET['d']), 0, 14);

--- a/addons/calendar/style.css
+++ b/addons/calendar/style.css
@@ -1,0 +1,49 @@
+#calendrier {
+	margin: 0 auto;
+}
+#calendrier,
+#calendrier caption {
+	background: rgba(0, 0, 0, .02);
+}
+
+#calendrier caption {
+	padding: 15px 0 20px;
+}
+
+#calendrier caption > a {
+	padding: 5px 10px;
+}
+
+#calendrier td {
+	width: 30px;
+	height: 30px;
+	border-radius: 3px;
+	border: 1px solid transparent;
+	empty-cells: hide;
+	text-align: center;
+	line-height: 30px;
+	color: rgba(42, 42, 42, .3);
+	position: relative;
+}
+
+#calendrier td a {
+	color: rgba(42, 42, 42, .8);
+	display: inline-block;
+	width: 100%;
+	height: 100%;
+}
+
+#calendrier td a:hover {
+	color: #000;
+}
+
+#calendrier td a::before {
+	content: "";
+	background-color: #2196F3;
+	position: absolute;
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	left: 14px;
+	bottom: 2px;
+}

--- a/addons/readmore/readmore.php
+++ b/addons/readmore/readmore.php
@@ -9,11 +9,13 @@
 #
 # *** LICENSE ***
 
-# This plugin replaces the {plugin_readmore} tag in the public template with
+# This plugin replaces the {addon_readmore} tag in the public template with
 # HTML for "read-also like" thumbnails.
 
 // include this addon
-$GLOBALS['addons'][] = array('tag' => '{plugin_readmore}', 'callback_function' => 'addon_readmore');
+$GLOBALS['addons'][] = array(
+	'name' => 'readmore',
+);
 
 // returns HTML <table> calender
 function addon_readmore() {
@@ -71,6 +73,3 @@ function addon_readmore() {
 
 
 }
-
-
-

--- a/themes/default/list.html
+++ b/themes/default/list.html
@@ -8,10 +8,10 @@
 	<meta name="viewport" content="width=device-width, user-scalable=yes" />
 	<meta name="keywords" content="{keywords}" />
 	<meta name="description" content="{article_chapo}" />
-	<link rel="stylesheet" href="{style}/style.css" />
 	<link rel="alternate" type="application/rss+xml" title="RSS - Articles" href="rss.php" />
 	<link rel="alternate" type="application/atom+xml" title="ATOM - Articles" href="atom.php" />
 	<link rel="canonical" href="{article_lien}" />
+	{includes.css}
 </head>
 <body>
 
@@ -34,7 +34,7 @@
 		</nav>
 		<nav id="calendar">
 			<p class="nav-title">Trouver un article</p>
-			{calendrier}
+			{addon_calendar}
 		</nav>
 		<nav id="lastcom">
 			<p class="nav-title">Derniers commentaires</p>
@@ -64,6 +64,8 @@
 <footer>
 	<div><a href="/">{blog_auteur}</a> - <span lang="en">Theme by <a href="http://lehollandaisvolant.net/">Timo van Neerden</a></span></div>
 </footer>
+
+{includes.js}
 <script>
 function insertTag(e, startTag, endTag) {
 	var seekField = e;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1,4 +1,3 @@
-@charset "utf-8";
 @font-face {
   font-family: "Roboto";
   font-style: normal;
@@ -40,7 +39,7 @@ html, body {
 }
 
 
-/* GENERAL STUFF 
+/* GENERAL STUFF
 ------------------------------------------------------------------- */
 
 a {
@@ -93,7 +92,7 @@ q, blockquote {
 
 
 
-/* TOP 
+/* TOP
 ------------------------------------------------------------------------ */
 #top-bar {
 	display: flex;
@@ -256,56 +255,6 @@ q, blockquote {
 #links ul li {
 	padding: 5px 15px 0;
 	height: 40px;
-}
-
-#calendrier {
-	margin: 0 auto;
-}
-#calendrier,
-#calendrier caption {
-	background: rgba(0, 0, 0, .02);
-}
-
-#calendrier caption {
-	padding: 15px 0 20px;
-}
-
-#calendrier caption > a {
-	padding: 5px 10px;
-}
-
-#calendrier td {
-	width: 30px;
-	height: 30px;
-	border-radius: 3px;
-	border: 1px solid transparent;
-	empty-cells: hide;
-	text-align: center;
-	line-height: 30px;
-	color: rgba(42, 42, 42, .3);
-	position: relative;
-}
-
-#calendrier td a {
-	color: rgba(42, 42, 42, .8);
-	display: inline-block;
-	width: 100%;
-	height: 100%;
-}
-
-#calendrier td a:hover {
-	color: #000;
-}
-
-#calendrier td a::before {
-	content: "";
-	background-color: #2196F3;
-	position: absolute;
-	width: 5px;
-	height: 5px;
-	border-radius: 50%;
-	left: 14px;
-	bottom: 2px;
 }
 
 #lastcom {
@@ -596,7 +545,7 @@ q, blockquote {
 }
 
 .com-footer {
-	text-align: right;	
+	text-align: right;
 	padding: 15px 0 0
 }
 
@@ -636,7 +585,7 @@ q, blockquote {
 }
 
 
-/* Formulaire commentaires 
+/* Formulaire commentaires
 ------------------------------------------ */
 #postcom {
 	padding: 15px;
@@ -815,7 +764,7 @@ p.formatbut {
 	content: "« ";
 }
 
-/* PAGE FOOTER 
+/* PAGE FOOTER
 ------------------------------------------------------------------------ */
 body > footer {
 	padding: 15px 0 30px;
@@ -930,6 +879,3 @@ body > footer a {
 	}
 
 }
-
-
-


### PR DESCRIPTION
Finally, changes to get addons more complete are not so bigs.

Changes for themes:
- `{style}` removed.
- Use only `{includes.css}` between `head` blocks (like any CSS file) to include both current theme and addons styles.
- Use `{includes.js}` to include all JS files needed by addons (in the bottom page, do not load scripts in the `head` block).

Assumptions for themes:
- [x] Styles are defined into `style.css`. Other imports could be done inside that file.
- [x] For styles, do not add `@charset`, it is defined by default before any import.

---

Changes for addons:
- The only needed keyword is `name` (on old addons, it was the `tag` keyword).
- This is how to declare an addon:
```php
$GLOBALS['addons'][] = array(
	'name' => 'calendar',  // the same name of the file without ".php"
	'css' => 'style.css',  // could be an array of files
	'js' => 'script.js',  // could be an array of files
);
```

Assumptions for addons:
- [x] Each addon has its own directory into `addons` based on this scheme: `addons/addon_name/addon_name.php`.
- [x] To include an addon into your theme, use `{addon_NAME}` (replace `NAME` with the addon name, ie. "calendar").
- [x]  It __must__ define `function addon_NAME()` (replace `NAME` with the addon name, ie. "calendar"). This is the function callback called to print the addon. Apart that, you can add as many functions as needed, with names you want and use BlogoText ones too.
- [x] For styles, do not add `@charset`, it is defined by default before any import.

---

Note: I translated "calendrier" to "calendar".

What do you think? Changes to apply?
It will certainly need a page into admin backend to disable/enable addons. We could create a text file in each addon directroy like `.disable`. If this file is present, do not use the addon.