### PR TITLE
Fix SQL on mode comments

### DIFF
--- a/index.php
+++ b/index.php
@@ -203,7 +203,7 @@ else {
 					$sql_date = "bt_date LIKE ? ";
 					break;
 				case 'commentaires':
-					$sql_date = "c.bt_date LIKE ? ";
+					$sql_date = "c.bt_id LIKE ? ";
 					break;
 				default:
 					$sql_date = "bt_id LIKE ? ";


### PR DESCRIPTION
Fix `Erreur 89208 : SQLSTATE[HY000]: General error: 1 no such column: c.bt_date` when calling `index.php?mode=comments`.